### PR TITLE
Add Support for Automatic EFS Backups to S3. Add `tags` and `attributes`

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -89,7 +89,7 @@ module "efs" {
 
 # EFS backup to S3
 module "efs_backup" {
-  source                             = "git::https://github.com/cloudposse/terraform-aws-efs-backup.git?ref=tags/0.3.2"
+  source                             = "git::https://github.com/cloudposse/terraform-aws-efs-backup.git?ref=tags/0.3.3"
   name                               = "${var.name}"
   stage                              = "${var.stage}"
   namespace                          = "${var.namespace}"

--- a/main.tf
+++ b/main.tf
@@ -100,6 +100,7 @@ module "efs_backup" {
   noncurrent_version_expiration_days = "${var.noncurrent_version_expiration_days}"
   ssh_key_pair                       = "${var.keypair}"
   modify_security_group              = "false"
+  datapipeline_config                = "${var.datapipeline_config}"
   delimiter                          = "${var.delimiter}"
   attributes                         = ["${compact(concat(var.attributes, list("efs-backup")))}"]
   tags                               = "${var.tags}"

--- a/main.tf
+++ b/main.tf
@@ -6,7 +6,7 @@ module "elastic_beanstalk_application" {
   stage       = "${var.stage}"
   description = "${var.description}"
   delimiter   = "${var.delimiter}"
-  attributes  = "${compact(concat(var.attributes, list("app")))}"
+  attributes  = ["${compact(concat(var.attributes, list("app")))}"]
   tags        = "${var.tags}"
 }
 
@@ -52,7 +52,7 @@ module "elastic_beanstalk_environment" {
     }"
 
   delimiter  = "${var.delimiter}"
-  attributes = "${compact(concat(var.attributes, list("env")))}"
+  attributes = ["${compact(concat(var.attributes, list("env")))}"]
   tags       = "${var.tags}"
 }
 
@@ -63,7 +63,7 @@ module "ecr" {
   name       = "${var.name}"
   stage      = "${var.stage}"
   delimiter  = "${var.delimiter}"
-  attributes = "${compact(concat(var.attributes, list("ecr")))}"
+  attributes = ["${compact(concat(var.attributes, list("ecr")))}"]
   tags       = "${var.tags}"
 }
 
@@ -83,7 +83,7 @@ module "efs" {
   security_groups = ["${module.elastic_beanstalk_environment.security_group_id}", "${module.efs_backup.security_group_id}"]
 
   delimiter  = "${var.delimiter}"
-  attributes = "${compact(concat(var.attributes, list("efs")))}"
+  attributes = ["${compact(concat(var.attributes, list("efs")))}"]
   tags       = "${var.tags}"
 }
 
@@ -101,7 +101,7 @@ module "efs_backup" {
   ssh_key_pair                       = "${var.keypair}"
   modify_security_group              = "false"
   delimiter                          = "${var.delimiter}"
-  attributes                         = "${compact(concat(var.attributes, list("efs-backup")))}"
+  attributes                         = ["${compact(concat(var.attributes, list("efs-backup")))}"]
   tags                               = "${var.tags}"
 }
 
@@ -126,6 +126,6 @@ module "cicd" {
   image_repo_name    = "${module.ecr.repository_name}"
   image_tag          = "${var.image_tag}"
   delimiter          = "${var.delimiter}"
-  attributes         = "${compact(concat(var.attributes, list("cicd")))}"
+  attributes         = ["${compact(concat(var.attributes, list("cicd")))}"]
   tags               = "${var.tags}"
 }

--- a/main.tf
+++ b/main.tf
@@ -6,7 +6,7 @@ module "elastic_beanstalk_application" {
   stage       = "${var.stage}"
   description = "${var.description}"
   delimiter   = "${var.delimiter}"
-  attributes  = "${concat(var.attributes, list("app"))}"
+  attributes  = "${compact(concat(var.attributes, list("app")))}"
   tags        = "${var.tags}"
 }
 
@@ -52,7 +52,7 @@ module "elastic_beanstalk_environment" {
     }"
 
   delimiter  = "${var.delimiter}"
-  attributes = "${concat(var.attributes, list("env"))}"
+  attributes = "${compact(concat(var.attributes, list("env")))}"
   tags       = "${var.tags}"
 }
 
@@ -63,7 +63,7 @@ module "ecr" {
   name       = "${var.name}"
   stage      = "${var.stage}"
   delimiter  = "${var.delimiter}"
-  attributes = "${concat(var.attributes, list("ecr"))}"
+  attributes = "${compact(concat(var.attributes, list("ecr")))}"
   tags       = "${var.tags}"
 }
 
@@ -83,7 +83,7 @@ module "efs" {
   security_groups = ["${module.elastic_beanstalk_environment.security_group_id}", "${module.efs_backup.security_group_id}"]
 
   delimiter  = "${var.delimiter}"
-  attributes = "${concat(var.attributes, list("efs"))}"
+  attributes = "${compact(concat(var.attributes, list("efs")))}"
   tags       = "${var.tags}"
 }
 
@@ -101,7 +101,7 @@ module "efs_backup" {
   ssh_key_pair                       = "${var.keypair}"
   modify_security_group              = "false"
   delimiter                          = "${var.delimiter}"
-  attributes                         = "${concat(var.attributes, list("efs-backup"))}"
+  attributes                         = "${compact(concat(var.attributes, list("efs-backup")))}"
   tags                               = "${var.tags}"
 }
 
@@ -126,6 +126,6 @@ module "cicd" {
   image_repo_name    = "${module.ecr.repository_name}"
   image_tag          = "${var.image_tag}"
   delimiter          = "${var.delimiter}"
-  attributes         = "${concat(var.attributes, list("cicd"))}"
+  attributes         = "${compact(concat(var.attributes, list("cicd")))}"
   tags               = "${var.tags}"
 }

--- a/main.tf
+++ b/main.tf
@@ -1,6 +1,6 @@
 # Elastic Beanstalk Application
 module "elastic_beanstalk_application" {
-  source      = "git::https://github.com/cloudposse/terraform-aws-elastic-beanstalk-application.git?ref=tags/0.1.2"
+  source      = "git::https://github.com/cloudposse/terraform-aws-elastic-beanstalk-application.git?ref=tags/0.1.3"
   namespace   = "${var.namespace}"
   name        = "${var.name}"
   stage       = "${var.stage}"
@@ -9,7 +9,7 @@ module "elastic_beanstalk_application" {
 
 # Elastic Beanstalk Environment
 module "elastic_beanstalk_environment" {
-  source        = "git::https://github.com/cloudposse/terraform-aws-elastic-beanstalk-environment.git?ref=tags/0.2.3"
+  source        = "git::https://github.com/cloudposse/terraform-aws-elastic-beanstalk-environment.git?ref=tags/0.2.4"
   attributes    = ["eb"]
   namespace     = "${var.namespace}"
   name          = "${var.name}"

--- a/main.tf
+++ b/main.tf
@@ -6,7 +6,7 @@ module "elastic_beanstalk_application" {
   stage       = "${var.stage}"
   description = "${var.description}"
   delimiter   = "${var.delimiter}"
-  attributes  = ["${compact(concat(var.attributes, list("app")))}"]
+  attributes  = ["${compact(concat(var.attributes, list("eb-app")))}"]
   tags        = "${var.tags}"
 }
 
@@ -52,7 +52,7 @@ module "elastic_beanstalk_environment" {
     }"
 
   delimiter  = "${var.delimiter}"
-  attributes = ["${compact(concat(var.attributes, list("env")))}"]
+  attributes = ["${compact(concat(var.attributes, list("eb-env")))}"]
   tags       = "${var.tags}"
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -154,3 +154,8 @@ variable "env_vars" {
   default     = {}
   description = "Map of custom ENV variables to be provided to the Jenkins application running on Elastic Beanstalk, e.g. env_vars = { JENKINS_USER = 'admin' JENKINS_PASS = 'xxxxxx' }"
 }
+
+variable "noncurrent_version_expiration_days" {
+  default     = 35
+  description = "Backup S3 bucket noncurrent version expiration days"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -156,6 +156,25 @@ variable "env_vars" {
 }
 
 variable "noncurrent_version_expiration_days" {
-  default     = 35
+  type        = "string"
+  default     = "35"
   description = "Backup S3 bucket noncurrent version expiration days"
+}
+
+variable "delimiter" {
+  type        = "string"
+  default     = "-"
+  description = "Delimiter to be used between `name`, `namespace`, `stage`, etc."
+}
+
+variable "attributes" {
+  type        = "list"
+  default     = []
+  description = "Additional attributes (e.g. `policy` or `role`)"
+}
+
+variable "tags" {
+  type        = "map"
+  default     = {}
+  description = "Additional tags (e.g. `map('BusinessUnit`,`XYZ`)"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -178,3 +178,15 @@ variable "tags" {
   default     = {}
   description = "Additional tags (e.g. `map('BusinessUnit`,`XYZ`)"
 }
+
+variable "datapipeline_config" {
+  type        = "map"
+  description = "DataPipeline configuration options"
+
+  default = {
+    instance_type = "t2.micro"
+    email         = ""
+    period        = "24 hours"
+    timeout       = "60 Minutes"
+  }
+}

--- a/variables.tf
+++ b/variables.tf
@@ -51,7 +51,7 @@ variable "availability_zones" {
 
 variable "healthcheck_url" {
   type        = "string"
-  default     = "/"
+  default     = "/login"
   description = "Application Health Check URL. Elastic Beanstalk will call this URL to check the health of the application running on EC2 instances"
 }
 


### PR DESCRIPTION
## What

* Added `terraform-aws-efs-backup` module


## Why

* `EFS` filesystem (`Jenkins` state) will be automatically (on schedule) backed up to an `S3` bucket via `DataPipeline`
