### PR TITLE
Add slaves support

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ## Introduction
 
 `terraform-aws-jenkins` is a Terraform module to build a Docker image with [Jenkins](https://jenkins.io/), save it to an [ECR](https://aws.amazon.com/ecr/) repo,
-and deploy to [Elastic Beanstalk](https://aws.amazon.com/elasticbeanstalk/) running [Docker](https://www.docker.com/) stack.
+and deploy to [Elastic Beanstalk](https://aws.amazon.com/elasticbeanstalk/) running [Docker](https://www.docker.com/).
 
 This is an enterprise-ready, scalable and highly-available architecture and the CI/CD pattern to build and deploy Jenkins.
 

--- a/main.tf
+++ b/main.tf
@@ -45,12 +45,12 @@ module "elastic_beanstalk_environment" {
   env_default_value            = "${var.env_default_value}"
 
   # Provide EFS DNS name to EB in the `EFS_HOST` ENV var. EC2 instance will mount to the EFS filesystem and use it to store Jenkins state
-  # Add slaves Security Group `EC2_SECURITY_GROUPS` (comma-separated if more than one). Will be used by Jenkins to init the EC2 plugin to launch slaves inside the Security Group
+  # Add slaves Security Group `JENKINS_SLAVE_SECURITY_GROUPS` (comma-separated if more than one). Will be used by Jenkins to init the EC2 plugin to launch slaves inside the Security Group
   env_vars = "${
       merge(
         map(
           "EFS_HOST", "${module.efs.dns_name}",
-          "EC2_SECURITY_GROUPS", "${aws_security_group.slaves.id}"
+          "JENKINS_SLAVE_SECURITY_GROUPS", "${aws_security_group.slaves.id}"
         ), var.env_vars
       )
     }"

--- a/main.tf
+++ b/main.tf
@@ -12,7 +12,7 @@ module "elastic_beanstalk_application" {
 
 # Elastic Beanstalk Environment
 module "elastic_beanstalk_environment" {
-  source        = "git::https://github.com/cloudposse/terraform-aws-elastic-beanstalk-environment.git?ref=tags/0.2.6"
+  source        = "git::https://github.com/cloudposse/terraform-aws-elastic-beanstalk-environment.git?ref=tags/0.2.8"
   namespace     = "${var.namespace}"
   name          = "${var.name}"
   stage         = "${var.stage}"

--- a/main.tf
+++ b/main.tf
@@ -176,3 +176,49 @@ resource "aws_security_group" "slaves" {
 
   tags = "${module.label_slaves.tags}"
 }
+
+# Policy document with permissions to launch new EC2 instances
+# https://wiki.jenkins.io/display/JENKINS/Amazon+EC2+Plugin
+data "aws_iam_policy_document" "slaves" {
+  statement {
+    sid = "AllowLaunchingEC2Instances"
+
+    actions = [
+      "ec2:DescribeSpotInstanceRequests",
+      "ec2:CancelSpotInstanceRequests",
+      "ec2:GetConsoleOutput",
+      "ec2:RequestSpotInstances",
+      "ec2:RunInstances",
+      "ec2:StartInstances",
+      "ec2:StopInstances",
+      "ec2:TerminateInstances",
+      "ec2:CreateTags",
+      "ec2:DeleteTags",
+      "ec2:DescribeInstances",
+      "ec2:DescribeKeyPairs",
+      "ec2:DescribeRegions",
+      "ec2:DescribeImages",
+      "ec2:DescribeAvailabilityZones",
+      "ec2:DescribeSecurityGroups",
+      "ec2:DescribeSubnets",
+      "iam:PassRole",
+    ]
+
+    resources = ["*"]
+    effect    = "Allow"
+  }
+}
+
+# Policy for the EB EC2 instance profile to allow launching Jenkins slaves
+resource "aws_iam_policy" "slaves" {
+  name        = "${module.label_slaves.id}"
+  path        = "/"
+  description = "Policy for EC2 instance profile to allow launching Jenkins slaves"
+  policy      = "${data.aws_iam_policy_document.slaves.json}"
+}
+
+# Attach Policy to the EC2 instance profile to allow Jenkins master to launch and control slave EC2 instances
+resource "aws_iam_role_policy_attachment" "slaves" {
+  role       = "${module.elastic_beanstalk_environment.ec2_instance_profile_role_name}"
+  policy_arn = "${aws_iam_policy.slaves.arn}"
+}


### PR DESCRIPTION
## what
* Add Security Group for EC2 slaves
* Attach IAM Policy to the Elastic Beanstalk EC2 instance profile

## why
* To place Jenkins slaves into a dedicated Security Group and allow the master to connect via SSH
* To allow Jenkins master to launch and control slave EC2 instances

## references
* https://wiki.jenkins.io/display/JENKINS/Amazon+EC2+Plugin
