### PR TITLE
Add option to use IP address as EFS mount point

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -49,7 +49,8 @@ module "elastic_beanstalk_environment" {
   env_vars = "${
       merge(
         map(
-          "EFS_HOST", "${var.use_efs_ip_address ? module.efs.mount_target_ids[0] : module.efs.dns_name}",
+          "EFS_HOST", "${var.use_efs_ip_address ? module.efs.mount_target_ips[0] : module.efs.dns_name}",
+          "USE_EFS_IP", "${var.use_efs_ip_address}",
           "JENKINS_SLAVE_SECURITY_GROUPS", "${aws_security_group.slaves.id}"
         ), var.env_vars
       )
@@ -100,7 +101,7 @@ module "efs_backup" {
   region                             = "${var.aws_region}"
   vpc_id                             = "${var.vpc_id}"
   efs_mount_target_id                = "${element(module.efs.mount_target_ids, 0)}"
-  use_ip_address                     = "${var.use_efs_ip_address ? module.efs.mount_target_ips[0] : false}"
+  use_ip_address                     = "${var.use_efs_ip_address}"
   noncurrent_version_expiration_days = "${var.noncurrent_version_expiration_days}"
   ssh_key_pair                       = "${var.ssh_key_pair}"
   modify_security_group              = "false"

--- a/main.tf
+++ b/main.tf
@@ -49,7 +49,7 @@ module "elastic_beanstalk_environment" {
   env_vars = "${
       merge(
         map(
-          "EFS_HOST", "${module.efs.dns_name}",
+          "EFS_HOST", "${var.use_efs_ip_address ? module.efs.mount_target_ids[0].ip_address : module.efs.dns_name}",
           "JENKINS_SLAVE_SECURITY_GROUPS", "${aws_security_group.slaves.id}"
         ), var.env_vars
       )
@@ -112,7 +112,7 @@ module "efs_backup" {
 
 # CodePipeline/CodeBuild to build Jenkins Docker image, store it to a ECR repo, and deploy it to Elastic Beanstalk running Docker stack
 module "cicd" {
-  source              = "git::https://github.com/cloudposse/terraform-aws-cicd.git?ref=tags/0.4.6"
+  source              = "git::git?ref=tags/0.4.6"
   namespace           = "${var.namespace}"
   name                = "${var.name}"
   stage               = "${var.stage}"

--- a/main.tf
+++ b/main.tf
@@ -74,7 +74,7 @@ module "ecr" {
 
 # EFS to store Jenkins state (settings, jobs, etc.)
 module "efs" {
-  source             = "../terraform-aws-efs"
+  source             = "git::https://github.com/cloudposse/terraform-aws-efs.git?ref=tags/0.3.2"
   namespace          = "${var.namespace}"
   name               = "${var.name}"
   stage              = "${var.stage}"

--- a/main.tf
+++ b/main.tf
@@ -49,7 +49,7 @@ module "elastic_beanstalk_environment" {
   env_vars = "${
       merge(
         map(
-          "EFS_HOST", "${var.use_efs_ip_address ? module.efs.mount_target_ids[0].ip_address : module.efs.dns_name}",
+          "EFS_HOST", "${var.use_efs_ip_address ? module.efs.mount_target_ids[0] : module.efs.dns_name}",
           "JENKINS_SLAVE_SECURITY_GROUPS", "${aws_security_group.slaves.id}"
         ), var.env_vars
       )
@@ -73,7 +73,7 @@ module "ecr" {
 
 # EFS to store Jenkins state (settings, jobs, etc.)
 module "efs" {
-  source             = "git::https://github.com/cloudposse/terraform-aws-efs.git?ref=tags/0.3.1"
+  source             = "../terraform-aws-efs"
   namespace          = "${var.namespace}"
   name               = "${var.name}"
   stage              = "${var.stage}"
@@ -100,7 +100,7 @@ module "efs_backup" {
   region                             = "${var.aws_region}"
   vpc_id                             = "${var.vpc_id}"
   efs_mount_target_id                = "${element(module.efs.mount_target_ids, 0)}"
-  use_ip_address                     = "false"
+  use_ip_address                     = "${var.use_efs_ip_address ? module.efs.mount_target_ips[0] : false}"
   noncurrent_version_expiration_days = "${var.noncurrent_version_expiration_days}"
   ssh_key_pair                       = "${var.ssh_key_pair}"
   modify_security_group              = "false"
@@ -112,7 +112,7 @@ module "efs_backup" {
 
 # CodePipeline/CodeBuild to build Jenkins Docker image, store it to a ECR repo, and deploy it to Elastic Beanstalk running Docker stack
 module "cicd" {
-  source              = "git::git?ref=tags/0.4.6"
+  source              = "git::https://github.com/cloudposse/terraform-aws-cicd.git?ref=tags/0.4.6"
   namespace           = "${var.namespace}"
   name                = "${var.name}"
   stage               = "${var.stage}"

--- a/variables.tf
+++ b/variables.tf
@@ -195,3 +195,7 @@ variable "datapipeline_config" {
     timeout       = "60 Minutes"
   }
 }
+
+variable "use_efs_ip_address" {
+  default = false
+}

--- a/variables.tf
+++ b/variables.tf
@@ -197,5 +197,5 @@ variable "datapipeline_config" {
 }
 
 variable "use_efs_ip_address" {
-  default = false
+  default = "false"
 }


### PR DESCRIPTION
## What
* Add option to use IP address as EFS mount point

## Why
* When VPC does not support DNS hostnames we should use IP address for EFS mount target

## Plan
