### PR TITLE
Bump `terraform-aws-efs-backup` version to `0.3.8`

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -94,7 +94,7 @@ module "efs" {
 
 # EFS backup to S3
 module "efs_backup" {
-  source                             = "git::https://github.com/cloudposse/terraform-aws-efs-backup.git?ref=tags/0.3.5"
+  source                             = "git::https://github.com/cloudposse/terraform-aws-efs-backup.git?ref=tags/0.3.8"
   name                               = "${var.name}"
   stage                              = "${var.stage}"
   namespace                          = "${var.namespace}"


### PR DESCRIPTION
## what
* Bump `terraform-aws-efs-backup` version to `0.3.8`

## why
* Removed `AllowedValues ` for EC2 instance types in `terraform-aws-efs-backup`
* Allowed instance types are optional parameters
* If we use a list of instance type to restrict the values, we'll have to support and update it every time AWS releases new instances

## references
* https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/parameters-section-structure.html