### PR TITLE
Bump `terraform-aws-ecr` version to `0.2.4`

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -63,7 +63,7 @@ module "elastic_beanstalk_environment" {
 
 # Elastic Container Registry Docker Repository
 module "ecr" {
-  source     = "git::https://github.com/cloudposse/terraform-aws-ecr.git?ref=tags/0.2.3"
+  source     = "git::https://github.com/cloudposse/terraform-aws-ecr.git?ref=tags/0.2.4"
   namespace  = "${var.namespace}"
   name       = "${var.name}"
   stage      = "${var.stage}"


### PR DESCRIPTION
## what
* Bump `terraform-aws-ecr` version to `0.2.4`

## why
* It defines `aws_ecr_lifecycle_policy` to expunge old Docker images
