### PR TITLE
Bump `terraform-aws-cicd` version to `0.5.2`

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -113,7 +113,7 @@ module "efs_backup" {
 
 # CodePipeline/CodeBuild to build Jenkins Docker image, store it to a ECR repo, and deploy it to Elastic Beanstalk running Docker stack
 module "cicd" {
-  source              = "git::https://github.com/cloudposse/terraform-aws-cicd.git?ref=tags/0.5.1"
+  source              = "git::https://github.com/cloudposse/terraform-aws-cicd.git?ref=tags/0.5.2"
   namespace           = "${var.namespace}"
   name                = "${var.name}"
   stage               = "${var.stage}"


### PR DESCRIPTION
## what
* Bumped `terraform-aws-cicd` version to `0.5.2`

## why
* It adds `STAGE` environment variable for tagging Docker images in ECR